### PR TITLE
Update Maiden Voyage relaunch landing copy

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -55,10 +55,7 @@ export default function HeroSection() {
               <div className="inline-block px-4 sm:px-6 md:px-8 py-1.5 sm:py-2 md:py-2.5 bg-sunrise-coral border-2 border-sunrise-coral rounded-full">
                 <p className="text-[10px] sm:text-xs md:text-sm lg:text-base text-white text-center">
                   <span className="font-semibold">
-                    New market rewards live now for EURO markets!
-                  </span>{" "}
-                  <span className="font-normal">
-                    Deposit to earn yield & Ledger marks for the $TIDE airdrop.
+                    Maiden Voyages are relaunching soon.
                   </span>
                 </p>
               </div>
@@ -71,14 +68,23 @@ export default function HeroSection() {
                 }`}
               >
                 <span className="block whitespace-nowrap">
-                  A Safer Harbor For Leverage,
+                  Deposit Once.
                 </span>
                 <span className="block whitespace-nowrap">
-                  Uncharted Waters For Yield.
+                  Lifetime Yield.
                 </span>
               </h1>
               <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-r from-transparent via-nautical-blue/30 to-transparent blur-3xl" />
             </div>
+            <p
+              className={`mt-3 max-w-3xl text-center text-sm sm:text-base text-harbor-white/90 transition-all duration-1000 delay-300 ease-out ${
+                isLoaded ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
+              }`}
+            >
+              Deposit once during Maiden Voyage to own a share of market revenue
+              for life. 5% of revenue from mint and redeem fees plus collateral
+              yield goes to voyage participants.
+            </p>
 
             <div 
               className={`mt-3 sm:mt-4 md:mt-5 space-y-3 sm:space-y-4 transition-all duration-1000 delay-500 ease-out ${
@@ -107,7 +113,7 @@ export default function HeroSection() {
                   }}
                   className="w-[110px] sm:w-[120px] md:w-[130px] lg:w-[140px] flex-shrink-0 px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 text-[10px] sm:text-xs md:text-sm font-semibold border border-white text-white rounded-full hover:bg-white/10 transition-all text-center whitespace-nowrap"
                 >
-                  Learn more
+                  How it works
                 </button>
                 <a
                   href="https://app.harborfinance.io/genesis"
@@ -115,7 +121,7 @@ export default function HeroSection() {
                   rel="noopener noreferrer"
                   className="w-[110px] sm:w-[150px] md:w-[160px] lg:w-[170px] flex-shrink-0 px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 text-[10px] sm:text-xs md:text-sm font-semibold bg-white text-nautical-blue border border-white rounded-full hover:bg-white/90 transition-all text-center whitespace-nowrap shadow-[0_0_20px_rgba(255,255,255,0.3)] hover:shadow-[0_0_30px_rgba(255,255,255,0.5)]"
                 >
-                  Launch App
+                  Join First Voyage
                 </a>
               </div>
             </div>

--- a/src/components/MaidenVoyageSection.tsx
+++ b/src/components/MaidenVoyageSection.tsx
@@ -80,6 +80,11 @@ export default function MaidenVoyageSection() {
     };
   }, []);
 
+  const hasLiveMaidenVoyages = maidenVoyages.some((voyage) =>
+    voyage.markets.some((market) => market.phase === "live")
+  );
+  const shouldShowMarketsPanel = isLoading || loadError || hasLiveMaidenVoyages;
+
   return (
     <section
       id="maiden-voyage"
@@ -91,11 +96,29 @@ export default function MaidenVoyageSection() {
           <div className="flex flex-col gap-6 h-full">
             <div className="flex flex-col text-left min-w-0">
               <h2 className="leading-none text-3xl sm:text-4xl md:text-4xl lg:text-5xl xl:text-5xl 2xl:text-6xl font-bold text-white tracking-tight whitespace-nowrap">
-                Maiden Voyage
+                Maiden Voyages
               </h2>
               <div className="space-y-4 mt-4">
                 <p className="text-white text-sm sm:text-base">
-                  Earn 10x Marks per dollar per day, plus 100 Marks bonus per $ deposited at the end of maiden voyage. Early depositors get an additional 100 Marks/$ bonus.
+                  Each market begins with a Maiden Voyage. Deposit once during
+                  launch to earn a share of market revenue for life.
+                </p>
+                <p className="text-white text-sm sm:text-base">
+                  5% of market revenue is reserved for Maiden Voyage
+                  participants, including all mint and redeem fees plus all
+                  collateral yield.
+                </p>
+              </div>
+              <div className="mt-4 border border-white/30 bg-white/10 p-3 sm:p-4">
+                <p className="text-[10px] uppercase tracking-[0.25em] text-white/80">
+                  First relaunch voyage
+                </p>
+                <p className="mt-1 text-white text-base sm:text-lg font-semibold">
+                  ETH vs USD
+                </p>
+                <p className="mt-1 text-white/90 text-xs sm:text-sm">
+                  Earn yield on USD, get leveraged ETH exposure, and avoid
+                  liquidations.
                 </p>
               </div>
 
@@ -106,7 +129,7 @@ export default function MaidenVoyageSection() {
                   rel="noopener noreferrer"
                   className="w-[140px] sm:w-[150px] md:w-[160px] lg:w-[170px] flex-shrink-0 px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 text-[10px] sm:text-xs md:text-sm font-semibold bg-white text-nautical-blue border border-white rounded-full hover:bg-white/90 transition-colors text-center whitespace-nowrap"
                 >
-                  Launch App
+                  Join First Voyage
                 </a>
                 <Link
                   href="https://docs.harborfinance.io/"
@@ -114,18 +137,20 @@ export default function MaidenVoyageSection() {
                   rel="noopener noreferrer"
                   className="inline-block w-[140px] sm:w-[150px] md:w-[160px] lg:w-[170px] flex-shrink-0 px-2 sm:px-3 md:px-4 py-2 sm:py-2.5 text-[10px] sm:text-xs md:text-sm font-semibold border border-white text-white rounded-full hover:bg-white/10 transition-colors text-center whitespace-nowrap"
                 >
-                  Learn more
+                  How it works
                 </Link>
               </div>
             </div>
 
-            <div className="mt-4 pt-4 border-t border-white/25">
-              <LiveMaidenVoyageMarkets
-                voyages={maidenVoyages}
-                isLoading={isLoading}
-                hasError={loadError}
-              />
-            </div>
+            {shouldShowMarketsPanel && (
+              <div className="mt-4 pt-4 border-t border-white/25">
+                <LiveMaidenVoyageMarkets
+                  voyages={maidenVoyages}
+                  isLoading={isLoading}
+                  hasError={loadError}
+                />
+              </div>
+            )}
           </div>
         </div>
 
@@ -142,7 +167,7 @@ export default function MaidenVoyageSection() {
                 </div>
                 <div>
                   <p className="text-nautical-blue text-sm sm:text-base">
-                    Deposit any token via ParaSwap
+                    Deposit once during Maiden Voyage
                   </p>
                 </div>
               </div>
@@ -152,7 +177,7 @@ export default function MaidenVoyageSection() {
                 </div>
                 <div>
                   <p className="text-nautical-blue text-sm sm:text-base">
-                    Earn Ledger Marks
+                    5% of market revenue is shared with voyage participants
                   </p>
                 </div>
               </div>
@@ -162,7 +187,8 @@ export default function MaidenVoyageSection() {
                 </div>
                 <div>
                   <p className="text-nautical-blue text-sm sm:text-base">
-                    After maiden voyage: claim ha & hs tokens and earn real yield
+                    You keep lifetime participation even after withdrawing;
+                    remaining deposits receive a yield-share boost
                   </p>
                 </div>
               </div>
@@ -247,8 +273,7 @@ function LiveMaidenVoyageMarkets({
           </span>
         </span>
         <span className="flex items-center gap-1 font-semibold text-nautical-blue justify-end">
-          Earn Ledger Marks
-          <img src="/marks.png" alt="Marks" className="w-3.5 h-3.5 opacity-70" />
+          Lifetime yield share
         </span>
       </div>
     </div>
@@ -259,17 +284,12 @@ function LiveMaidenVoyageMarkets({
       <div className="space-y-3">
         {isLoading && (
           <p className="text-xs text-nautical-blue/70">
-            Loading maiden voyage markets...
+            Loading Maiden Voyage markets...
           </p>
         )}
         {!isLoading && hasError && (
           <p className="text-xs text-nautical-blue/70">
-            Maiden voyage markets unavailable right now.
-          </p>
-        )}
-        {!isLoading && !hasError && allMarkets.length === 0 && (
-          <p className="text-xs text-nautical-blue/70">
-            No maiden voyage markets yet.
+            Maiden Voyage markets unavailable right now.
           </p>
         )}
         {!isLoading && !hasError && activeSection && (


### PR DESCRIPTION
## Summary
- update hero and Maiden Voyage section messaging to reflect the Deposit Once relaunch and lifetime yield-share positioning
- add explicit 5% market revenue language (mint/redeem fees + collateral yield), plus ETH vs USD first voyage callout
- simplify Maiden Voyage market panel behavior by hiding the panel when no live voyages are available

## Test plan
- [x] Verify `HeroSection` copy and CTA labels match new relaunch language
- [x] Verify `MaidenVoyageSection` copy reflects lifetime participation and boosted share wording
- [x] Verify Maiden Voyage markets panel does not render when there are no live voyages
- [x] Run lints for edited files

Made with [Cursor](https://cursor.com)